### PR TITLE
Turn the alarm list overlay on

### DIFF
--- a/src/common/pollingManager.js
+++ b/src/common/pollingManager.js
@@ -1,7 +1,7 @@
 import Rx from 'rxjs';
 
 /** A helper class for managing polling calls */
-class RxEventSwitchManager {
+class PollingManager {
 
   constructor() {
     this.emitter = new Rx.Subject();
@@ -12,7 +12,7 @@ class RxEventSwitchManager {
    * Emits an event
    * @param {string} eventName The name of the event (can be anything but text is useful for debugging)
    * @param {function} eventCallback A function that returns an observable
-   * @param {function} delayInterval (Optional) The time in ms to wait before calling the callback 
+   * @param {number} delayInterval (Optional) The time in ms to wait before calling the callback 
    */
   emit(eventName, eventCallback, delayInterval = 0) {
     const callEvent = Rx.Observable.of(eventName)
@@ -23,4 +23,4 @@ class RxEventSwitchManager {
 
 }
 
-export default RxEventSwitchManager;
+export default PollingManager;

--- a/src/components/flyout/deviceDetailFlyout.js
+++ b/src/components/flyout/deviceDetailFlyout.js
@@ -12,7 +12,7 @@ import ApiService from '../../common/apiService';
 import Timeline from '../charts/timeline';
 import AlarmsGrid from '../alarmList/alarmsGrid';
 import Config from '../../common/config';
-import RxEventSwitchManager from '../../common/rxEventSwitchManager';
+import PollingManager from '../../common/pollingManager';
 
 import './deviceDetailFlyout.css';
 
@@ -102,14 +102,14 @@ class DeviceDetailFlyout extends Component {
       }
     };
 
-    this.eventManager = new RxEventSwitchManager();
+    this.pollingManager = new PollingManager();
 
     this.handleOptionChange = this.handleOptionChange.bind(this);
   }
 
   componentDidMount() {
     this.subscriptions.push(
-      this.eventManager
+      this.pollingManager
         .stream
         .do(_ => this.refresh(`intervalRefresh`, Config.INTERVALS.TELEMETRY_UPDATE_MS))
         .subscribe(this.handleNewData)
@@ -255,7 +255,7 @@ class DeviceDetailFlyout extends Component {
   };
 
   refresh(eventName, delayAmount) {
-    this.eventManager.emit(eventName, this.createGetDataEvent, delayAmount);
+    this.pollingManager.emit(eventName, this.createGetDataEvent, delayAmount);
   }
 
   handleOptionChange(selectedKey) {


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Description of the change
The dashboard alarms loading overlay wasn't enabled. This PR enables the overlay.
Also rename the polling manager to have a better name.