### PR TITLE
Fix deep link auth issue

### DIFF
--- a/src/common/httpClient.js
+++ b/src/common/httpClient.js
@@ -55,11 +55,11 @@ function ajax(url, options) {
   // header is not valid, to tell the CSRF protection to allow
   // this request through (assuming that Auth is not mandatory,
   // e.g. during development).
-  options.headers['Csrf-Token'] = 'nocheck';
+  //options.headers['Csrf-Token'] = 'nocheck';
 
   auth.getAccessToken(accessToken => {
     if (accessToken) {
-      options.headers['Authorization'] = 'Bearer ' + accessToken;
+      //options.headers['Authorization'] = 'Bearer ' + accessToken;
     }
   });
 


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation
Instead of passing the full `href` to the auth service, pass only the location origin.