### PR TITLE
added event listner to close the flyouts

### DIFF
--- a/src/components/layout/main/main.js
+++ b/src/components/layout/main/main.js
@@ -39,7 +39,7 @@ class Main extends Component {
     return (
       <div className="main-container">
         <LeftNav onClick={this.props.actions.hideFlyout} />
-        <div className="main-content-container">
+        <div className="main-content-container" onClick={this.props.actions.hideFlyout}>
           {this.props.children}
         </div>
         <Flyout {...flyoutProp} />


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation 
All the Flyouts are closed when user clicks outside anywhere in the body.

Issue is listed in https://microsoft.sharepoint.com/:o:/r/teams/Azure_IoT/_layouts/15/WopiFrame.aspx?sourcedoc=%7B51c1dfb0-d513-4f35-9e3f-6b1df968e99a%7D&action=edit&wd=target%28%2F%2FUX%20and%20Design%2FDesign%20Triage%20-%20Priorities%20list.one%7Cb73fd7fa-bb5f-4758-8dd0-5306232f181d%2FPriorities%20list%7Cd234d634-2459-43d3-bf40-d9238f7d9396%2F%29.
...


**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
