### PR TITLE
fixed the Job details devicegrid filtering

### DIFF
--- a/src/components/pages/maintenance/maintenance.js
+++ b/src/components/pages/maintenance/maintenance.js
@@ -327,7 +327,8 @@ class MaintenancePage extends Component {
       onDeviceGridReady: this.onDeviceGridReady,
       onAlarmGridReady: this.onAlarmGridReady,
       onRuleGridReady: this.onRuleGridReady,
-      onContextMenuChange: this.onContextMenuChange
+      onContextMenuChange: this.onContextMenuChange,
+      onDeviceJobSoftSelectChange : this.onDeviceJobSoftSelectChange
     };
   };
 

--- a/src/components/systemStatusDetailsGrid/systemStatusDetailsGrid.js
+++ b/src/components/systemStatusDetailsGrid/systemStatusDetailsGrid.js
@@ -97,9 +97,8 @@ class SystemStatusDetailsGrid extends Component {
   }
 
   render() {
-    const { detailsDevices, jobDetails, systemStatusGridSelectedDevices, btnActions, devices } = this.props;
+    const { detailsDevices, jobDetails, systemStatusGridSelectedDevices, btnActions } = this.props;
     const hasJobs = (detailsDevices || []).length > 0;
-    const deviceIds = new Set(detailsDevices.map(({ deviceId }) => deviceId));
     const devicesGridProps = {
       rowData: systemStatusGridSelectedDevices,
       onSoftSelectChange: this.onSoftSelectDeviceGrid,

--- a/src/components/systemStatusDetailsGrid/systemStatusDetailsGrid.js
+++ b/src/components/systemStatusDetailsGrid/systemStatusDetailsGrid.js
@@ -49,7 +49,7 @@ class SystemStatusDetailsGrid extends Component {
 
   onSoftSelectDeviceGrid(device) {
     this.setState({ softSelectedDeviceId: device.Id });
-    this.props.btnActions.onSoftSelectDeviceGrid(device);
+    this.props.btnActions.onDeviceJobSoftSelectChange(device);
   }
 
   componentDidMount() {
@@ -101,7 +101,7 @@ class SystemStatusDetailsGrid extends Component {
     const hasJobs = (detailsDevices || []).length > 0;
     const deviceIds = new Set(detailsDevices.map(({ deviceId }) => deviceId));
     const devicesGridProps = {
-      rowData: devices.filter(({ Id }) => deviceIds.has(Id)),
+      rowData: systemStatusGridSelectedDevices,
       onSoftSelectChange: this.onSoftSelectDeviceGrid,
       onContextMenuChange: btnActions.onContextMenuChange,
       softSelectId: this.state.softSelectedDeviceId,


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation 
When user clicks on job details row only show that particular device grid row instead of all devices effected all devices.

...

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
