### PR TITLE
Docker container excessively privileged running root user

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -4,6 +4,10 @@ MAINTAINER Devis Lucato (https://github.com/dluc)
 
 LABEL Tags="Azure,IoT,Solutions,React,SPA"
 
+ARG user=pcsuser
+
+RUN adduser -D -h /home/$user -s /bin/bash $user $user
+
 COPY ./ /app
 WORKDIR /app
 
@@ -19,9 +23,14 @@ RUN apk update && apk upgrade \
  && apk add --no-cache nginx \
  && apk del --force --purge alpine-keys apk-tools \
  && rm -rf /var/cache/apk /etc/apk /lib/apk \
- && mkdir /app/logs
+ && mkdir /app/logs \
+ && chown -R $user:$user /app \
+ && mkdir -p /var/lib/nginx /var/cache/nginx /var/tmp/nginx /var/log/nginx \
+ && chown -R $user:$user /var/lib/nginx /var/cache/nginx /var/tmp/nginx /var/log/nginx
 
-EXPOSE 80 443
+EXPOSE 8080 8443
 VOLUME /app/logs
 
 ENTRYPOINT ["/bin/sh", "/app/run.sh"]
+
+USER $user

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -4,9 +4,9 @@ MAINTAINER Devis Lucato (https://github.com/dluc)
 
 LABEL Tags="Azure,IoT,Solutions,React,SPA"
 
-ARG user=pcsuser
+ARG user=app
 
-RUN adduser -D -h /home/$user -s /bin/bash $user $user
+RUN addgroup $user && adduser -D -G $user $user
 
 COPY ./ /app
 WORKDIR /app
@@ -28,7 +28,7 @@ RUN apk update && apk upgrade \
  && mkdir -p /var/lib/nginx /var/cache/nginx /var/tmp/nginx /var/log/nginx \
  && chown -R $user:$user /var/lib/nginx /var/cache/nginx /var/tmp/nginx /var/log/nginx
 
-EXPOSE 8080 8443
+EXPOSE 10080 10443
 VOLUME /app/logs
 
 ENTRYPOINT ["/bin/sh", "/app/run.sh"]

--- a/scripts/docker/content/nginx.conf
+++ b/scripts/docker/content/nginx.conf
@@ -19,7 +19,7 @@ http {
 
   server {
     gzip on;
-    listen 8080;
+    listen 10080;
     server_name 127.0.0.1 localhost;
     root /app/build;
 

--- a/scripts/docker/content/nginx.conf
+++ b/scripts/docker/content/nginx.conf
@@ -1,7 +1,8 @@
+daemon           off;
 worker_processes 1;
 
 error_log  /app/logs/error.log;
-pid        /var/run/nginx.pid;
+pid        /app/logs/nginx.pid;
 
 events {
   worker_connections 1024;
@@ -18,7 +19,7 @@ http {
 
   server {
     gzip on;
-    listen 80;
+    listen 8080;
     server_name 127.0.0.1 localhost;
     root /app/build;
 

--- a/scripts/docker/content/run.sh
+++ b/scripts/docker/content/run.sh
@@ -3,4 +3,4 @@ set -ex
 
 # serve the app via nginx
 mkdir -p /app/logs
-nginx -g 'daemon off;' -c /app/nginx.conf
+nginx -c /app/nginx.conf

--- a/scripts/docker/run
+++ b/scripts/docker/run
@@ -10,8 +10,8 @@ STABLE_VERSION="1.0.0-preview"
 
 if [ "$1" == "testing" ]; then
   echo "Starting Remote Monitoring Web UI [testing version] ..."
-  docker run -it -p 10080:80 -p 10443:443 $DOCKER_IMAGE:testing
+  docker run -it -p 10080:8080 -p 10443:8443 $DOCKER_IMAGE:testing
 else
   echo "Starting Remote Monitoring Web UI [$STABLE_VERSION] ..."
-  docker run -it -p 10080:80 -p 10443:443 $DOCKER_IMAGE:$STABLE_VERSION
+  docker run -it -p 10080:8080 -p 10443:8443 $DOCKER_IMAGE:$STABLE_VERSION
 fi

--- a/scripts/docker/run
+++ b/scripts/docker/run
@@ -10,8 +10,8 @@ STABLE_VERSION="1.0.0-preview"
 
 if [ "$1" == "testing" ]; then
   echo "Starting Remote Monitoring Web UI [testing version] ..."
-  docker run -it -p 10080:8080 -p 10443:8443 $DOCKER_IMAGE:testing
+  docker run -it -p 10080:10080 -p 10443:10443 $DOCKER_IMAGE:testing
 else
   echo "Starting Remote Monitoring Web UI [$STABLE_VERSION] ..."
-  docker run -it -p 10080:8080 -p 10443:8443 $DOCKER_IMAGE:$STABLE_VERSION
+  docker run -it -p 10080:10080 -p 10443:10443 $DOCKER_IMAGE:$STABLE_VERSION
 fi

--- a/scripts/docker/run.cmd
+++ b/scripts/docker/run.cmd
@@ -13,12 +13,12 @@ IF "%1"=="testing" goto :TESTING
 
 :STABLE
   echo Starting Remote Monitoring Web UI [%STABLE_VERSION%] ...
-  docker run -it -p 10080:80 -p 10443:443 %DOCKER_IMAGE%:%STABLE_VERSION%
+  docker run -it -p 10080:8080 -p 10443:8443 %DOCKER_IMAGE%:%STABLE_VERSION%
   goto :END
 
 :TESTING
   echo Starting Remote Monitoring Web UI [testing version] ...
-  docker run -it -p 10080:80 -p 10443:443 %DOCKER_IMAGE%:testing
+  docker run -it -p 10080:8080 -p 10443:8443 %DOCKER_IMAGE%:testing
   goto :END
 
 

--- a/scripts/docker/run.cmd
+++ b/scripts/docker/run.cmd
@@ -13,12 +13,12 @@ IF "%1"=="testing" goto :TESTING
 
 :STABLE
   echo Starting Remote Monitoring Web UI [%STABLE_VERSION%] ...
-  docker run -it -p 10080:8080 -p 10443:8443 %DOCKER_IMAGE%:%STABLE_VERSION%
+  docker run -it -p 10080:10080 -p 10443:10443 %DOCKER_IMAGE%:%STABLE_VERSION%
   goto :END
 
 :TESTING
   echo Starting Remote Monitoring Web UI [testing version] ...
-  docker run -it -p 10080:8080 -p 10443:8443 %DOCKER_IMAGE%:testing
+  docker run -it -p 10080:10080 -p 10443:10443 %DOCKER_IMAGE%:testing
   goto :END
 
 


### PR DESCRIPTION
* Add default non-root user 'pcsuser'
* Install sudo and add 'pcsuser' as sudoer
* Run service as 'pcsuser'

PBI[2211778]

# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

Without explicitly defining a running user in a Dockerfile definition, the root user is utilized by default.
Each respective Dockerfile should explicitly define a user and mandate that user to be the service runner via the USER instruction. Further, the service user should also have a defined GROUP. Without one, the primary group for the user will fall back to the root group.

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
