### PR TITLE
Add header tooltips to ag-grids

### DIFF
--- a/src/utilities/methods.js
+++ b/src/utilities/methods.js
@@ -46,13 +46,18 @@ export const camelCaseReshape = (response, model) => {
   return reshape(camelCaseKeys(response), model);
 };
 
-/** A helper method for translating headerNames of columnDefs */
+/**
+ * A helper method for translating headerNames and headerTooltips of columnDefs.
+ * If headerTooltip is provided, it will be translated.
+ * If headerTooltip is not provided, the headerName will be used to ensure headers
+ * can be deciphered even when the column is too narrow to show the entire header.
+ */
 export const translateColumnDefs = (t, columnDefs) => {
-  return columnDefs.map(columnDef =>
-    columnDef.headerName
-      ? { ...columnDef, headerName: t(columnDef.headerName) }
-      : columnDef
-  );
+  return columnDefs.map(columnDef => {
+    const headerName = columnDef.headerName ? t(columnDef.headerName) : undefined;
+    const headerTooltip = columnDef.headerTooltip ? t(columnDef.headerTooltip) : headerName;
+    return { ...columnDef, headerName, headerTooltip };
+  });
 }
 
 /** A helper method for creating comparator methods for sorting arrays of objects */


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

Add header tooltips to ag-grids.  Add translation support for headerTooltip in columndefs. If headerTooltip is not provided, then use the translated headerName as the tooltip to ensure headers can be deciphered even when too narrow to show the whole thing.

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
