### PR TITLE
Add error checking for large logo files

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -429,12 +429,12 @@
     "nameAndLogo": "Name and logo",
     "nameLogoDescription": "Edit logo and name in the site header.",
     "replaceLogo": "Replace logo image",
-    "logoDescription": "Recommended logo size 24 x 24 px.\nSupported file formats:\n\t.SVG\n\t.PNG\n\t.JPEG\n\t.JPG",
+    "logoDescription": "Recommended logo size 24 x 24 px.\nMaximum logo size 300 KB.\nSupported file formats:\n\t.SVG\n\t.PNG\n\t.JPEG\n\t.JPG",
     "applicationName": "Application name",
     "currentLogo": "Current logo",
     "edit": "Edit",
     "checkmark": "Checkmark",
-    "uploadError": "Unable to upload file, please check the file type and try again",
+    "uploadError": "Unable to upload file, please check the file type and size and try again.",
     "error": "Error"
   },
   "maintenance": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -429,12 +429,12 @@
     "nameAndLogo": "Name and logo",
     "nameLogoDescription": "Edit logo and name in the site header.",
     "replaceLogo": "Replace logo image",
-    "logoDescription": "Recommended logo size 24 x 24 px.\nMaximum logo size 300 KB.\nSupported file formats:\n\t.SVG\n\t.PNG\n\t.JPEG\n\t.JPG",
+    "logoDescription": "Recommended logo size: 24 x 24 px.\nMaximum logo size: 300 KB.\nSupported file formats:\n\t.SVG\n\t.PNG\n\t.JPEG\n\t.JPG",
     "applicationName": "Application name",
     "currentLogo": "Current logo",
     "edit": "Edit",
     "checkmark": "Checkmark",
-    "uploadError": "Unable to upload file, please check the file type and size and try again.",
+    "uploadError": "Unable to upload file, please check the file type/size and try again.",
     "error": "Error"
   },
   "maintenance": {

--- a/src/app.config.js
+++ b/src/app.config.js
@@ -37,7 +37,7 @@ const Config = {
     closed: 'closed',
     acknowledged: 'acknowledged'
   },
-  maxLogoFileSizeBytes: 307200
+  maxLogoFileSizeInBytes: 307200
 };
 
 export default Config;

--- a/src/app.config.js
+++ b/src/app.config.js
@@ -36,7 +36,8 @@ const Config = {
     open: 'open',
     closed: 'closed',
     acknowledged: 'acknowledged'
-  }
+  },
+  maxLogoFileSizeBytes: 307200
 };
 
 export default Config;

--- a/src/components/app/flyouts/settings/applicationSettings.js
+++ b/src/components/app/flyouts/settings/applicationSettings.js
@@ -121,7 +121,7 @@ class ApplicationSettings extends Component {
       validating: true,
       validFile: false
     });
-    if (isValidExtension(file)) {
+    if (file.size <= Config.maxLogoFileSizeBytes && isValidExtension(file)) {
       this.setState({
         newLogoName: file.name,
         previewLogo: URL.createObjectURL(file),

--- a/src/components/app/flyouts/settings/applicationSettings.js
+++ b/src/components/app/flyouts/settings/applicationSettings.js
@@ -121,7 +121,7 @@ class ApplicationSettings extends Component {
       validating: true,
       validFile: false
     });
-    if (file.size <= Config.maxLogoFileSizeBytes && isValidExtension(file)) {
+    if (file.size <= Config.maxLogoFileSizeInBytes && isValidExtension(file)) {
       this.setState({
         newLogoName: file.name,
         previewLogo: URL.createObjectURL(file),


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
Max logo size (in java) is 300 KB. Have UI reject any logo > 300 kb, and include information on this limit.
This relates to the following PRs:
https://github.com/Azure/pcs-storage-adapter-java/pull/55
https://github.com/Azure/pcs-config-java/pull/72
**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
