### PR TITLE
Add Rule Diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "redux-observable": "0.17.0",
     "reselect": "3.0.1",
     "rxjs": "5.5.2",
-    "tsiclient": "1.1.19"
+    "tsiclient": "1.1.19",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "enzyme": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "redux-observable": "0.17.0",
     "reselect": "3.0.1",
     "rxjs": "5.5.2",
-    "tsiclient": "1.1.19",
-    "uuid": "^3.3.2"
+    "tsiclient": "1.1.19"
   },
   "devDependencies": {
     "enzyme": "3.2.0",

--- a/src/components/pages/dashboard/dashboard.container.js
+++ b/src/components/pages/dashboard/dashboard.container.js
@@ -3,7 +3,6 @@
 import { connect } from 'react-redux';
 import { translate } from 'react-i18next';
 import {
-  epics as appEpics,
   redux as appRedux,
   getActiveDeviceGroup,
   getAzureMapsKey,
@@ -51,7 +50,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   fetchRules: () => dispatch(rulesEpics.actions.fetchRules()),
   updateTimeInterval: timeInterval => dispatch(appRedux.actions.updateTimeInterval(timeInterval)),
-  updateCurrentWindow: (currentWindow) => dispatch(appEpics.actions.updateCurrentWindow(currentWindow))
+  updateCurrentWindow: (currentWindow) => dispatch(appRedux.actions.updateCurrentWindow(currentWindow))
 });
 
 export const DashboardContainer = translate()(connect(mapStateToProps, mapDispatchToProps)(Dashboard));

--- a/src/components/pages/dashboard/dashboard.container.js
+++ b/src/components/pages/dashboard/dashboard.container.js
@@ -3,6 +3,7 @@
 import { connect } from 'react-redux';
 import { translate } from 'react-i18next';
 import {
+  epics as appEpics,
   redux as appRedux,
   getAzureMapsKey,
   getSolutionSettingsError,
@@ -47,7 +48,8 @@ const mapStateToProps = state => ({
 // Wrap the dispatch method
 const mapDispatchToProps = dispatch => ({
   fetchRules: () => dispatch(rulesEpics.actions.fetchRules()),
-  updateTimeInterval: timeInterval => dispatch(appRedux.actions.updateTimeInterval(timeInterval))
+  updateTimeInterval: timeInterval => dispatch(appRedux.actions.updateTimeInterval(timeInterval)),
+  updateCurrentWindow: (currentWindow) => dispatch(appEpics.actions.updateCurrentWindow(currentWindow))
 });
 
 export const DashboardContainer = translate()(connect(mapStateToProps, mapDispatchToProps)(Dashboard));

--- a/src/components/pages/dashboard/dashboard.js
+++ b/src/components/pages/dashboard/dashboard.js
@@ -65,6 +65,8 @@ export class Dashboard extends Component {
     this.dashboardRefresh$ = new Subject(); // Restarts all streams
     this.telemetryRefresh$ = new Subject();
     this.panelsRefresh$ = new Subject();
+
+    this.props.updateCurrentWindow('Dashboard');
   }
 
   componentDidMount() {

--- a/src/components/pages/dashboard/dashboard.test.js
+++ b/src/components/pages/dashboard/dashboard.test.js
@@ -20,7 +20,8 @@ describe('Dashboard Component', () => {
       rulesError: undefined,
       rulesIsPending: false,
       fetchRules: () => {},
-      t: () => {}
+      t: () => {},
+      updateCurrentWindow: () => {}
     };
 
     const wrapper = shallow(

--- a/src/components/pages/devices/devices.container.js
+++ b/src/components/pages/devices/devices.container.js
@@ -10,7 +10,11 @@ import {
   getDevicesLastUpdated,
   getDevicesPendingStatus
 } from 'store/reducers/devicesReducer';
-import { getDeviceGroups, getDeviceGroupError } from 'store/reducers/appReducer';
+import {
+  epics as appEpics,
+  getDeviceGroups,
+  getDeviceGroupError
+} from 'store/reducers/appReducer';
 
 // Pass the devices status
 const mapStateToProps = state => ({
@@ -24,7 +28,8 @@ const mapStateToProps = state => ({
 
 // Wrap the dispatch method
 const mapDispatchToProps = dispatch => ({
-  fetchDevices: () => dispatch(devicesEpics.actions.fetchDevices())
+  fetchDevices: () => dispatch(devicesEpics.actions.fetchDevices()),
+  updateCurrentWindow: (currentWindow) => dispatch(appEpics.actions.updateCurrentWindow(currentWindow))
 });
 
 export const DevicesContainer = translate()(connect(mapStateToProps, mapDispatchToProps)(Devices));

--- a/src/components/pages/devices/devices.container.js
+++ b/src/components/pages/devices/devices.container.js
@@ -11,7 +11,7 @@ import {
   getDevicesPendingStatus
 } from 'store/reducers/devicesReducer';
 import {
-  epics as appEpics,
+  redux as appRedux,
   getDeviceGroups,
   getDeviceGroupError
 } from 'store/reducers/appReducer';
@@ -29,7 +29,7 @@ const mapStateToProps = state => ({
 // Wrap the dispatch method
 const mapDispatchToProps = dispatch => ({
   fetchDevices: () => dispatch(devicesEpics.actions.fetchDevices()),
-  updateCurrentWindow: (currentWindow) => dispatch(appEpics.actions.updateCurrentWindow(currentWindow))
+  updateCurrentWindow: (currentWindow) => dispatch(appRedux.actions.updateCurrentWindow(currentWindow))
 });
 
 export const DevicesContainer = translate()(connect(mapStateToProps, mapDispatchToProps)(Devices));

--- a/src/components/pages/devices/devices.js
+++ b/src/components/pages/devices/devices.js
@@ -31,6 +31,8 @@ export class Devices extends Component {
       ...closedFlyoutState,
       contextBtns: null
     };
+
+    this.props.updateCurrentWindow('Devices');
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/components/pages/devices/devices.test.js
+++ b/src/components/pages/devices/devices.test.js
@@ -19,6 +19,7 @@ describe('Devices Component', () => {
       fetchDevices: () => {},
       changeDeviceGroup: (id) => {},
       t: () => {},
+      updateCurrentWindow: () => {}
     };
 
     const wrapper = shallow(

--- a/src/components/pages/maintenance/maintenance.container.js
+++ b/src/components/pages/maintenance/maintenance.container.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { translate } from 'react-i18next';
 import { Maintenance } from './maintenance';
 import {
+  epics as appEpics,
   redux as appRedux,
   getTheme,
   getTimeInterval,
@@ -39,7 +40,9 @@ const mapStateToProps = state => ({
 // Wrap the dispatch method
 const mapDispatchToProps = dispatch => ({
   fetchRules: () => dispatch(rulesEpics.actions.fetchRules()),
-  updateTimeInterval: timeInterval => dispatch(appRedux.actions.updateTimeInterval(timeInterval))
+  updateTimeInterval: timeInterval => dispatch(appRedux.actions.updateTimeInterval(timeInterval)),
+  updateCurrentWindow: (currentWindow) => dispatch(appEpics.actions.updateCurrentWindow(currentWindow)),
+  logEvent: diagnosticsModel => dispatch(appEpics.actions.logEvent(diagnosticsModel))
 });
 
 export const MaintenanceContainer = translate()(connect(mapStateToProps, mapDispatchToProps)(Maintenance));

--- a/src/components/pages/maintenance/maintenance.container.js
+++ b/src/components/pages/maintenance/maintenance.container.js
@@ -41,7 +41,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   fetchRules: () => dispatch(rulesEpics.actions.fetchRules()),
   updateTimeInterval: timeInterval => dispatch(appRedux.actions.updateTimeInterval(timeInterval)),
-  updateCurrentWindow: (currentWindow) => dispatch(appEpics.actions.updateCurrentWindow(currentWindow)),
+  updateCurrentWindow: (currentWindow) => dispatch(appRedux.actions.updateCurrentWindow(currentWindow)),
   logEvent: diagnosticsModel => dispatch(appEpics.actions.logEvent(diagnosticsModel))
 });
 

--- a/src/components/pages/maintenance/maintenance.js
+++ b/src/components/pages/maintenance/maintenance.js
@@ -47,6 +47,7 @@ export class Maintenance extends Component {
     if (!this.props.rulesLastUpdated) {
       this.props.fetchRules();
     }
+
     this.props.updateCurrentWindow('Maintenance');
     this.subscriptions = [];
   }

--- a/src/components/pages/maintenance/maintenance.js
+++ b/src/components/pages/maintenance/maintenance.js
@@ -47,7 +47,7 @@ export class Maintenance extends Component {
     if (!this.props.rulesLastUpdated) {
       this.props.fetchRules();
     }
-
+    this.props.updateCurrentWindow('Maintenance');
     this.subscriptions = [];
   }
 
@@ -235,7 +235,8 @@ export class Maintenance extends Component {
       refreshData: this.getData,
       onTimeIntervalChange: this.onTimeIntervalChange,
       timeInterval: this.props.timeInterval,
-      lastUpdated: this.state.lastUpdated
+      lastUpdated: this.state.lastUpdated,
+      logEvent: this.props.logEvent
     };
     const alertProps = {
       isPending: rulesIsPending || alertsIsPending,

--- a/src/components/pages/maintenance/maintenance.test.js
+++ b/src/components/pages/maintenance/maintenance.test.js
@@ -16,7 +16,8 @@ describe('Dashboard Component', () => {
       rulesLastUpdated: undefined,
       deviceEntities: {},
       fetchRules: () => {},
-      t: () => {}
+      t: () => {},
+      updateCurrentWindow: () => {}
     };
 
     const wrapper = shallow(

--- a/src/components/pages/maintenance/ruleDetails/ruleDetails.js
+++ b/src/components/pages/maintenance/ruleDetails/ruleDetails.js
@@ -362,7 +362,8 @@ export class RuleDetails extends Component {
                 onHardSelectChange={this.onHardSelectChange('rules')}
                 rowData={rule}
                 pagination={false}
-                refresh={this.props.fetchRules} />
+                refresh={this.props.fetchRules}
+                logEvent={this.props.logEvent} />
 
               <h4 className="sub-heading">{ t('maintenance.alertOccurrences') }</h4>
               <AlertOccurrencesGrid {...alertsGridProps} />

--- a/src/components/pages/rules/flyouts/editRuleFlyout.js
+++ b/src/components/pages/rules/flyouts/editRuleFlyout.js
@@ -20,7 +20,7 @@ export class EditRuleFlyout extends Component {
       <Flyout.Container>
         <Flyout.Header>
           <Flyout.Title>{t('rules.flyouts.editRule')}</Flyout.Title>
-          <Flyout.CloseBtn onClick={ this.onTopXClose } />
+          <Flyout.CloseBtn onClick={this.onTopXClose} />
         </Flyout.Header>
         <Flyout.Content>
           <Protected permission={permissions.updateRules}>{

--- a/src/components/pages/rules/flyouts/editRuleFlyout.js
+++ b/src/components/pages/rules/flyouts/editRuleFlyout.js
@@ -10,7 +10,7 @@ export class EditRuleFlyout extends Component {
 
   onTopXClose = () => {
     const { logEvent, onClose } = this.props;
-    logEvent(toDiagnosticsModel('TopXCancelClick', {}));
+    logEvent(toDiagnosticsModel('Rule_TopXCloseClick', {}));
     onClose();
   }
 

--- a/src/components/pages/rules/flyouts/editRuleFlyout.js
+++ b/src/components/pages/rules/flyouts/editRuleFlyout.js
@@ -1,29 +1,41 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-import React from 'react';
-import { permissions } from 'services/models';
+import React, { Component } from 'react';
+import { permissions, toDiagnosticsModel } from 'services/models';
 import { Protected, ProtectedError } from 'components/shared';
 import { RuleEditorContainer } from './ruleEditor';
 import Flyout from 'components/shared/flyout';
 
-export const EditRuleFlyout = ({ t, onClose, rule }) => (
-  <Flyout.Container>
-    <Flyout.Header>
-      <Flyout.Title>{t('rules.flyouts.editRule')}</Flyout.Title>
-      <Flyout.CloseBtn onClick={onClose} />
-    </Flyout.Header>
-    <Flyout.Content>
-      <Protected permission={permissions.updateRules}>{
-        (hasPermission, permission) =>
-          hasPermission
-            ? <RuleEditorContainer onClose={onClose} rule={rule} />
-            :
-            <div>
-              <ProtectedError t={t} permission={permission} />
-              <p>A read-only view will be added soon as part of another PBI.</p>
-            </div>
-      }
-      </Protected>
-    </Flyout.Content>
-  </Flyout.Container>
-);
+export class EditRuleFlyout extends Component {
+
+  onTopXClose = () => {
+    const { logEvent, onClose } = this.props;
+    logEvent(toDiagnosticsModel('TopXCancelClick', {}));
+    onClose();
+  }
+
+  render() {
+    const { onClose, t, rule } = this.props;
+    return (
+      <Flyout.Container>
+        <Flyout.Header>
+          <Flyout.Title>{t('rules.flyouts.editRule')}</Flyout.Title>
+          <Flyout.CloseBtn onClick={ this.onTopXClose } />
+        </Flyout.Header>
+        <Flyout.Content>
+          <Protected permission={permissions.updateRules}>{
+            (hasPermission, permission) =>
+              hasPermission
+                ? <RuleEditorContainer onClose={onClose} rule={rule} />
+                :
+                <div>
+                  <ProtectedError t={t} permission={permission} />
+                  <p>A read-only view will be added soon as part of another PBI.</p>
+                </div>
+          }
+          </Protected>
+        </Flyout.Content>
+      </Flyout.Container>
+    );
+  }
+}

--- a/src/components/pages/rules/flyouts/newRuleFlyout.js
+++ b/src/components/pages/rules/flyouts/newRuleFlyout.js
@@ -1,21 +1,33 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-import React from 'react';
-import { permissions } from 'services/models';
+import React, { Component }  from 'react';
+import { permissions, toDiagnosticsModel } from 'services/models';
 import { Protected } from 'components/shared';
 import { RuleEditorContainer } from './ruleEditor';
 import Flyout from 'components/shared/flyout';
 
-export const NewRuleFlyout = ({ t, onClose }) => (
-  <Flyout.Container>
-    <Flyout.Header>
-      <Flyout.Title>{t('rules.flyouts.newRule')}</Flyout.Title>
-      <Flyout.CloseBtn onClick={onClose} />
-    </Flyout.Header>
-    <Flyout.Content>
-      <Protected permission={permissions.createRules}>
-        <RuleEditorContainer onClose={onClose} />
-      </Protected>
-    </Flyout.Content>
-  </Flyout.Container>
-);
+export class NewRuleFlyout extends Component {
+
+  onTopXClose = () => {
+    const { logEvent, onClose } = this.props;
+    logEvent(toDiagnosticsModel('TopXCancelClick', {}));
+    onClose();
+  }
+
+ render () {
+  const { onClose, t } = this.props;
+  return (
+    <Flyout.Container>
+      <Flyout.Header>
+        <Flyout.Title>{t('rules.flyouts.newRule')}</Flyout.Title>
+        <Flyout.CloseBtn onClick={this.onTopXClose} />
+      </Flyout.Header>
+      <Flyout.Content>
+        <Protected permission={permissions.createRules}>
+          <RuleEditorContainer onClose={onClose} />
+        </Protected>
+      </Flyout.Content>
+    </Flyout.Container>
+  );
+ }
+}

--- a/src/components/pages/rules/flyouts/newRuleFlyout.js
+++ b/src/components/pages/rules/flyouts/newRuleFlyout.js
@@ -10,7 +10,7 @@ export class NewRuleFlyout extends Component {
 
   onTopXClose = () => {
     const { logEvent, onClose } = this.props;
-    logEvent(toDiagnosticsModel('TopXCancelClick', {}));
+    logEvent(toDiagnosticsModel('Rule_TopXCloseClick', {}));
     onClose();
   }
 

--- a/src/components/pages/rules/flyouts/ruleDetailsFlyout.js
+++ b/src/components/pages/rules/flyouts/ruleDetailsFlyout.js
@@ -28,11 +28,9 @@ export class RuleDetailsFlyout extends Component {
 
   onTopXClose = () => {
     const { logEvent, onClose } = this.props;
-
     if(this.state.isEditable) {
       logEvent(toDiagnosticsModel('Rule_TopXCloseClick', {}));
     }
-
     onClose();
   }
 

--- a/src/components/pages/rules/flyouts/ruleDetailsFlyout.js
+++ b/src/components/pages/rules/flyouts/ruleDetailsFlyout.js
@@ -30,14 +30,14 @@ export class RuleDetailsFlyout extends Component {
     const { logEvent, onClose } = this.props;
 
     if(this.state.isEditable) {
-      logEvent(toDiagnosticsModel('TopXCancelClick', {}));
+      logEvent(toDiagnosticsModel('Rule_TopXCloseClick', {}));
     }
 
     onClose();
   }
 
   goToEditMode = () => {
-    this.props.logEvent(toDiagnosticsModel('EditRuleClick', {}));
+    this.props.logEvent(toDiagnosticsModel('Rule_EditClick', {}));
      this.setState({ isEditable: true });
   }
 

--- a/src/components/pages/rules/flyouts/ruleDetailsFlyout.js
+++ b/src/components/pages/rules/flyouts/ruleDetailsFlyout.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 import { svgs } from 'utilities';
-import { permissions } from 'services/models';
+import { permissions, toDiagnosticsModel } from 'services/models';
 import { Btn, Protected, ProtectedError } from 'components/shared';
 import { RuleEditorContainer } from './ruleEditor';
 import { RuleViewerContainer } from './ruleViewer';
@@ -26,7 +26,20 @@ export class RuleDetailsFlyout extends Component {
     }
   }
 
-  goToEditMode = () => { this.setState({ isEditable: true }); }
+  onTopXClose = () => {
+    const { logEvent, onClose } = this.props;
+
+    if(this.state.isEditable) {
+      logEvent(toDiagnosticsModel('TopXCancelClick', {}));
+    }
+
+    onClose();
+  }
+
+  goToEditMode = () => {
+    this.props.logEvent(toDiagnosticsModel('EditRuleClick', {}));
+     this.setState({ isEditable: true });
+  }
 
   render() {
     const { t, onClose, rule } = this.props;
@@ -36,7 +49,7 @@ export class RuleDetailsFlyout extends Component {
       <Flyout.Container>
         <Flyout.Header>
           <Flyout.Title>{isEditable ? t('rules.flyouts.editRule') : t('rules.flyouts.viewRule')}</Flyout.Title>
-          <Flyout.CloseBtn onClick={onClose} />
+          <Flyout.CloseBtn onClick={this.onTopXClose} />
         </Flyout.Header>
         <Flyout.Content className="rule-details">
           {!isEditable

--- a/src/components/pages/rules/flyouts/ruleEditor/ruleEditor.js
+++ b/src/components/pages/rules/flyouts/ruleEditor/ruleEditor.js
@@ -32,9 +32,9 @@ import {
   ruleCalculations,
   ruleTimePeriods,
   ruleOperators,
-  toLogRuleModel,
+  toRuleDiagnosticsModel,
   toDiagnosticsModel,
-  toSinglePropertyLogModel
+  toSinglePropertyDiagnosticsModel
 } from 'services/models';
 import Config from 'app.config';
 
@@ -165,7 +165,7 @@ export class RuleEditor extends LinkedComponent {
             },
             error => this.setState({ error, isPending: false, changesApplied: true })
           );
-        logEvent(toLogRuleModel('Rule_ApplyClick', requestProps));
+        logEvent(toRuleDiagnosticsModel('Rule_ApplyClick', requestProps));
       }
     }
   }
@@ -176,7 +176,7 @@ export class RuleEditor extends LinkedComponent {
       fieldQueryPending: true,
       isPending: true
     });
-    logEvent(toSinglePropertyLogModel('Rule_DeviceGroupClick', 'DeviceGroup', value));
+    logEvent(toSinglePropertyDiagnosticsModel('Rule_DeviceGroupClick', 'DeviceGroup', value));
     this.getDeviceCountAndFields(value);
     this.formControlChange();
   }
@@ -218,12 +218,12 @@ export class RuleEditor extends LinkedComponent {
   //todo toggle button didn't support link
   onStatusToggle = ({ target: { value } }) => {
     this.setState({ formData: { ...this.state.formData, enabled: value } });
-    this.props.logEvent(toSinglePropertyLogModel('Rule_StatusToggle', 'RuleStatus', value ? 'Enabled' : 'Disabled'));
+    this.props.logEvent(toSinglePropertyDiagnosticsModel('Rule_StatusToggle', 'RuleStatus', value ? 'Enabled' : 'Disabled'));
     this.formControlChange();
   }
 
   onCalculationChange = ({ target: { value: { value = {} } } }) => {
-    this.props.logEvent(toSinglePropertyLogModel('Rule_CalculationClick', 'Calculation', value));
+    this.props.logEvent(toSinglePropertyDiagnosticsModel('Rule_CalculationClick', 'Calculation', value));
     this.formControlChange();
   }
 
@@ -240,14 +240,14 @@ export class RuleEditor extends LinkedComponent {
   }
 
   onSeverityChange = ({ target: { value } }) => {
-    this.props.logEvent(toSinglePropertyLogModel('Rule_SeverityLevelClick', 'SeverityLevel', value))
+    this.props.logEvent(toSinglePropertyDiagnosticsModel('Rule_SeverityLevelClick', 'SeverityLevel', value))
     this.formControlChange();
   }
 
   onCloseClick = () => {
     const { onClose, logEvent } = this.props;
     const rule = { ...this.state.formData };
-    logEvent(toLogRuleModel('Rule_CancelClick', rule));
+    logEvent(toRuleDiagnosticsModel('Rule_CancelClick', rule));
     onClose();
   }
 

--- a/src/components/pages/rules/flyouts/ruleEditor/ruleEditor.js
+++ b/src/components/pages/rules/flyouts/ruleEditor/ruleEditor.js
@@ -33,19 +33,12 @@ import {
   ruleTimePeriods,
   ruleOperators,
   toLogRuleModel,
-  toDiagnosticsModel
+  toDiagnosticsModel,
+  toSinglePropertyLogModel
 } from 'services/models';
 import Config from 'app.config';
 
 import './ruleEditor.css';
-import {
-  toDeviceGroupLogModel,
-  toCalculationModel,
-  toFieldChosenModel,
-  toOperatorChosenModel,
-  toSeverityModel,
-  toRuleStatusModel
-} from 'services/models/logEventModels';
 
 const Section = Flyout.Section;
 
@@ -183,7 +176,7 @@ export class RuleEditor extends LinkedComponent {
       fieldQueryPending: true,
       isPending: true
     });
-    logEvent(toDeviceGroupLogModel('Rule_DeviceGroupClick', value));
+    logEvent(toSinglePropertyLogModel('Rule_DeviceGroupClick', 'DeviceGroup', value));
     this.getDeviceCountAndFields(value);
     this.formControlChange();
   }
@@ -225,27 +218,29 @@ export class RuleEditor extends LinkedComponent {
   //todo toggle button didn't support link
   onStatusToggle = ({ target: { value } }) => {
     this.setState({ formData: { ...this.state.formData, enabled: value } });
-    this.props.logEvent(toRuleStatusModel('Rule_StatusToggle', value ? 'Enabled' : 'Disabled'));
+    this.props.logEvent(toSinglePropertyLogModel('Rule_StatusToggle', 'RuleStatus', value ? 'Enabled' : 'Disabled'));
     this.formControlChange();
   }
 
   onCalculationChange = ({ target: { value: { value = {} } } }) => {
-    this.props.logEvent(toCalculationModel('Rule_CalculationClick', value));
+    this.props.logEvent(toSinglePropertyLogModel('Rule_CalculationClick', 'Calculation', value));
     this.formControlChange();
   }
 
   onFieldChange = (index, { target: { value: { value = {} } } }) => {
-    this.props.logEvent(toFieldChosenModel('Rule_FieldClick', value, index));
+    var eventProperties = { 'FieldChosen': value, 'ConditionNumber': index };
+    this.props.logEvent(toDiagnosticsModel('Rule_FieldClick', eventProperties));
     this.formControlChange();
   }
 
   onOperatorChange = (index, { target: { value: { value = {} } } }) => {
-    this.props.logEvent(toOperatorChosenModel('Rule_OperatorClick', value, index));
+    var eventProperties = { 'OperatorChosen': value, 'ConditionNumber': index };
+    this.props.logEvent(toDiagnosticsModel('Rule_OperatorClick', eventProperties));
     this.formControlChange();
   }
 
   onSeverityChange = ({ target: { value } }) => {
-    this.props.logEvent(toSeverityModel('Rule_SeverityLevelClick', value))
+    this.props.logEvent(toSinglePropertyLogModel('Rule_SeverityLevelClick', 'SeverityLevel', value))
     this.formControlChange();
   }
 

--- a/src/components/pages/rules/flyouts/ruleEditor/ruleEditor.js
+++ b/src/components/pages/rules/flyouts/ruleEditor/ruleEditor.js
@@ -39,7 +39,7 @@ import Config from 'app.config';
 
 import './ruleEditor.css';
 import {
-  toDeviceGroupModel,
+  toDeviceGroupLogModel,
   toCalculationModel,
   toFieldChosenModel,
   toOperatorChosenModel,
@@ -183,7 +183,7 @@ export class RuleEditor extends LinkedComponent {
       fieldQueryPending: true,
       isPending: true
     });
-    logEvent(toDeviceGroupModel('DeviceGroupClick', value));
+    logEvent(toDeviceGroupLogModel('DeviceGroupClick', value));
     this.getDeviceCountAndFields(value);
     this.formControlChange();
   }

--- a/src/components/pages/rules/flyouts/ruleEditor/ruleEditor.js
+++ b/src/components/pages/rules/flyouts/ruleEditor/ruleEditor.js
@@ -119,7 +119,7 @@ export class RuleEditor extends LinkedComponent {
 
   addCondition = () => {
     this.conditionsLink.set([...this.conditionsLink.value, newCondition()]);
-    this.props.logEvent(toDiagnosticsModel('AddConditionClick', {}));
+    this.props.logEvent(toDiagnosticsModel('Rule_AddConditionClick', {}));
   }
 
   deleteCondition = (index) =>
@@ -172,7 +172,7 @@ export class RuleEditor extends LinkedComponent {
             },
             error => this.setState({ error, isPending: false, changesApplied: true })
           );
-        logEvent(toLogRuleModel('RuleApplyClick', requestProps));
+        logEvent(toLogRuleModel('Rule_ApplyClick', requestProps));
       }
     }
   }
@@ -183,7 +183,7 @@ export class RuleEditor extends LinkedComponent {
       fieldQueryPending: true,
       isPending: true
     });
-    logEvent(toDeviceGroupLogModel('DeviceGroupClick', value));
+    logEvent(toDeviceGroupLogModel('Rule_DeviceGroupClick', value));
     this.getDeviceCountAndFields(value);
     this.formControlChange();
   }
@@ -225,34 +225,34 @@ export class RuleEditor extends LinkedComponent {
   //todo toggle button didn't support link
   onStatusToggle = ({ target: { value } }) => {
     this.setState({ formData: { ...this.state.formData, enabled: value } });
-    this.props.logEvent(toRuleStatusModel('RuleStatus', value ? 'Enabled' : 'Disabled'));
+    this.props.logEvent(toRuleStatusModel('Rule_StatusToggle', value ? 'Enabled' : 'Disabled'));
     this.formControlChange();
   }
 
   onCalculationChange = ({ target: { value: { value = {} } } }) => {
-    this.props.logEvent(toCalculationModel('CalculationClick', value));
+    this.props.logEvent(toCalculationModel('Rule_CalculationClick', value));
     this.formControlChange();
   }
 
   onFieldChange = (index, { target: { value: { value = {} } } }) => {
-    this.props.logEvent(toFieldChosenModel('FieldClick', value, index));
+    this.props.logEvent(toFieldChosenModel('Rule_FieldClick', value, index));
     this.formControlChange();
   }
 
   onOperatorChange = (index, { target: { value: { value = {} } } }) => {
-    this.props.logEvent(toOperatorChosenModel('OperatorClick', value, index));
+    this.props.logEvent(toOperatorChosenModel('Rule_OperatorClick', value, index));
     this.formControlChange();
   }
 
   onSeverityChange = ({ target: { value } }) => {
-    this.props.logEvent(toSeverityModel('SeverityLevelClick', value))
+    this.props.logEvent(toSeverityModel('Rule_SeverityLevelClick', value))
     this.formControlChange();
   }
 
   onCloseClick = () => {
     const { onClose, logEvent } = this.props;
     const rule = { ...this.state.formData };
-    logEvent(toLogRuleModel('CancelClick', rule));
+    logEvent(toLogRuleModel('Rule_CancelClick', rule));
     onClose();
   }
 

--- a/src/components/pages/rules/rules.container.js
+++ b/src/components/pages/rules/rules.container.js
@@ -13,6 +13,7 @@ import {
 } from 'store/reducers/rulesReducer';
 import {
   epics as appEpics,
+  redux as appRedux,
   getDeviceGroups
 } from 'store/reducers/appReducer';
 
@@ -29,7 +30,7 @@ const mapStateToProps = state => ({
 // Wrap the dispatch method
 const mapDispatchToProps = dispatch => ({
   fetchRules: () => dispatch(rulesEpics.actions.fetchRules()),
-  updateCurrentWindow: (currentWindow) => dispatch(appEpics.actions.updateCurrentWindow(currentWindow)),
+  updateCurrentWindow: (currentWindow) => dispatch(appRedux.actions.updateCurrentWindow(currentWindow)),
   logEvent: diagnosticsModel => dispatch(appEpics.actions.logEvent(diagnosticsModel))
 });
 

--- a/src/components/pages/rules/rules.container.js
+++ b/src/components/pages/rules/rules.container.js
@@ -11,7 +11,10 @@ import {
   getRulesLastUpdated,
   getRulesPendingStatus
 } from 'store/reducers/rulesReducer';
-import { getDeviceGroups } from 'store/reducers/appReducer';
+import {
+  epics as appEpics,
+  getDeviceGroups
+} from 'store/reducers/appReducer';
 
 // Pass the devices status
 const mapStateToProps = state => ({
@@ -25,7 +28,9 @@ const mapStateToProps = state => ({
 
 // Wrap the dispatch method
 const mapDispatchToProps = dispatch => ({
-  fetchRules: () => dispatch(rulesEpics.actions.fetchRules())
+  fetchRules: () => dispatch(rulesEpics.actions.fetchRules()),
+  updateCurrentWindow: (currentWindow) => dispatch(appEpics.actions.updateCurrentWindow(currentWindow)),
+  logEvent: diagnosticsModel => dispatch(appEpics.actions.logEvent(diagnosticsModel))
 });
 
 export const RulesContainer = translate()(connect(mapStateToProps, mapDispatchToProps)(Rules));

--- a/src/components/pages/rules/rules.js
+++ b/src/components/pages/rules/rules.js
@@ -56,12 +56,10 @@ export class Rules extends Component {
 
   openNewRuleFlyout = () => {
     const { logEvent } = this.props;
-
     this.setState({
       openFlyoutName: 'newRule',
       selectedRuleId: ''
     });
-
     logEvent(toDiagnosticsModel('Rule_NewClick', {}));
   }
 

--- a/src/components/pages/rules/rules.js
+++ b/src/components/pages/rules/rules.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 import React, { Component } from 'react';
-import { permissions } from 'services/models';
+import { permissions, toDiagnosticsModel } from 'services/models';
 import { RulesGrid } from './rulesGrid';
 import { DeviceGroupDropdownContainer as DeviceGroupDropdown } from 'components/app/deviceGroupDropdown';
 import { ManageDeviceGroupsBtnContainer as ManageDeviceGroupsBtn } from 'components/app/manageDeviceGroupsBtn';
@@ -36,6 +36,8 @@ export class Rules extends Component {
     if (!this.props.lastUpdated && !this.props.error) {
       this.props.fetchRules();
     }
+
+    this.props.updateCurrentWindow('Rules');
   }
 
   componentWillReceiveProps(nextProps) {
@@ -52,10 +54,16 @@ export class Rules extends Component {
 
   closeFlyout = () => this.setState(closedFlyoutState);
 
-  openNewRuleFlyout = () => this.setState({
-    openFlyoutName: 'newRule',
-    selectedRuleId: ''
-  });
+  openNewRuleFlyout = () => {
+    const { logEvent } = this.props;
+
+    this.setState({
+      openFlyoutName: 'newRule',
+      selectedRuleId: ''
+    });
+
+    logEvent(toDiagnosticsModel('NewRuleClick', {}));
+  }
 
   onGridReady = gridReadyEvent => this.rulesGridApi = gridReadyEvent.api;
 
@@ -72,7 +80,8 @@ export class Rules extends Component {
       error,
       isPending,
       lastUpdated,
-      fetchRules
+      fetchRules,
+      logEvent
     } = this.props;
     const gridProps = {
       onGridReady: this.onGridReady,
@@ -80,7 +89,8 @@ export class Rules extends Component {
       onContextMenuChange: this.onContextMenuChange,
       t: this.props.t,
       deviceGroups: this.props.deviceGroups,
-      refresh: fetchRules
+      refresh: fetchRules,
+      logEvent: this.props.logEvent
     };
     return [
       <ContextMenu key="context-menu">
@@ -96,7 +106,7 @@ export class Rules extends Component {
         <RefreshBar refresh={fetchRules} time={lastUpdated} isPending={isPending} t={t} />
         { !!error && <AjaxError t={t} error={error} /> }
         {!error && <RulesGrid {...gridProps} />}
-        {this.state.openFlyoutName === 'newRule' && <NewRuleFlyout t={t} onClose={this.closeFlyout} />}
+        {this.state.openFlyoutName === 'newRule' && <NewRuleFlyout t={t} onClose={this.closeFlyout} logEvent={logEvent} />}
       </PageContent>
     ];
   }

--- a/src/components/pages/rules/rules.js
+++ b/src/components/pages/rules/rules.js
@@ -62,7 +62,7 @@ export class Rules extends Component {
       selectedRuleId: ''
     });
 
-    logEvent(toDiagnosticsModel('NewRuleClick', {}));
+    logEvent(toDiagnosticsModel('Rule_NewClick', {}));
   }
 
   onGridReady = gridReadyEvent => this.rulesGridApi = gridReadyEvent.api;

--- a/src/components/pages/rules/rules.test.js
+++ b/src/components/pages/rules/rules.test.js
@@ -19,7 +19,8 @@ describe('Rules Component', () => {
       lastUpdated: undefined,
       fetchRules: () => {},
       changeDeviceGroup: (id) => {},
-      t: () => {}
+      t: () => {},
+      updateCurrentWindow: () => {}
     };
 
     const wrapper = shallow(

--- a/src/components/pages/rules/rulesGrid/rulesGrid.js
+++ b/src/components/pages/rules/rulesGrid/rulesGrid.js
@@ -94,7 +94,7 @@ export class RulesGrid extends Component {
   }
 
   openEditRuleFlyout = () => {
-    this.props.logEvent(toDiagnosticsModel('EditRuleClick', {}));
+    this.props.logEvent(toDiagnosticsModel('Rule_EditClick', {}));
     this.setState({ openFlyoutName: 'edit' });
   }
 

--- a/src/components/pages/rules/rulesGrid/rulesGrid.js
+++ b/src/components/pages/rules/rulesGrid/rulesGrid.js
@@ -3,7 +3,7 @@
 import React, { Component } from 'react';
 import { Trans } from 'react-i18next';
 
-import { permissions } from 'services/models';
+import { permissions, toDiagnosticsModel } from 'services/models';
 import { Btn, PcsGrid, Protected } from 'components/shared';
 import { rulesColumnDefs, defaultRulesGridProps } from './rulesGridConfig';
 import { checkboxColumn } from 'components/shared/pcsGrid/pcsGridConfig';
@@ -93,7 +93,10 @@ export class RulesGrid extends Component {
     }
   }
 
-  openEditRuleFlyout = () => this.setState({ openFlyoutName: 'edit' });
+  openEditRuleFlyout = () => {
+    this.props.logEvent(toDiagnosticsModel('EditRuleClick', {}));
+    this.setState({ openFlyoutName: 'edit' });
+  }
 
   openStatusFlyout = () => this.setState({ openFlyoutName: 'status' });
 
@@ -104,9 +107,9 @@ export class RulesGrid extends Component {
   getOpenFlyout = () => {
     switch (this.state.openFlyoutName) {
       case 'view':
-        return <RuleDetailsFlyout onClose={this.closeFlyout} t={this.props.t} rule={this.state.softSelectedRule || this.state.selectedRules[0]} key="view-rule-flyout" />
+        return <RuleDetailsFlyout onClose={this.closeFlyout} t={this.props.t} rule={this.state.softSelectedRule || this.state.selectedRules[0]} key="view-rule-flyout" logEvent={this.props.logEvent} />
       case 'edit':
-        return <EditRuleFlyout onClose={this.closeFlyout} t={this.props.t} rule={this.state.softSelectedRule || this.state.selectedRules[0]} key="edit-rule-flyout" />
+        return <EditRuleFlyout onClose={this.closeFlyout} t={this.props.t} rule={this.state.softSelectedRule || this.state.selectedRules[0]} key="edit-rule-flyout" logEvent={this.props.logEvent} />
       case 'status':
         return <RuleStatusContainer onClose={this.closeFlyout} t={this.props.t} rules={this.state.selectedRules} key="edit-rule-flyout" />
       case 'delete':

--- a/src/services/models/diagnosticsModels.js
+++ b/src/services/models/diagnosticsModels.js
@@ -3,7 +3,8 @@
 export const toDiagnosticsRequestModel = (request = {}) => ({
   EventType: request.eventType,
   EventProperties: request.eventProperties,
-  UserProperties: request.userProperties
+  UserProperties: request.userProperties,
+  SessionId: request.sessionId
 });
 
 export const toDiagnosticsModel = (eventType, eventProperties) => ({

--- a/src/services/models/diagnosticsModels.js
+++ b/src/services/models/diagnosticsModels.js
@@ -2,7 +2,8 @@
 
 export const toDiagnosticsRequestModel = (request = {}) => ({
   EventType: request.eventType,
-  EventProperties: request.eventProperties
+  EventProperties: request.eventProperties,
+  UserProperties: request.userProperties
 });
 
 export const toDiagnosticsModel = (eventType, eventProperties) => ({

--- a/src/services/models/diagnosticsModels.js
+++ b/src/services/models/diagnosticsModels.js
@@ -3,7 +3,6 @@
 export const toDiagnosticsRequestModel = (request = {}) => ({
   EventType: request.eventType,
   EventProperties: request.eventProperties,
-  UserProperties: request.userProperties,
   SessionId: request.sessionId
 });
 

--- a/src/services/models/logEventModels.js
+++ b/src/services/models/logEventModels.js
@@ -4,7 +4,7 @@ import { toDiagnosticsModel } from 'services/models';
 
 export const toRuleDiagnosticsModel = (eventName, rule) =>
 {
-  var metadata = {
+  const metadata = {
     DeviceGroup: rule.groupId,
     Calculation : rule.calculation,
     TimePeriod: rule.timePeriod,
@@ -18,7 +18,6 @@ export const toRuleDiagnosticsModel = (eventName, rule) =>
 }
 
 export const toSinglePropertyDiagnosticsModel = (eventName, propertyTitle, property) => {
-  var metadata = {};
-  metadata[propertyTitle] = property;
+  const metadata = { [propertyTitle]: property };
   return toDiagnosticsModel(eventName, metadata);
 }

--- a/src/services/models/logEventModels.js
+++ b/src/services/models/logEventModels.js
@@ -2,11 +2,73 @@
 
 import { toDiagnosticsModel } from 'services/models';
 
-export const toLogRuleModel = (rule = {}) => ({
-  'DeviceGroup': rule.groupId,
-  'Calculation': rule.calculation,
-  'TimePeriod': rule.timePeriod,
-  'Severity': rule.severity
-});
+export const toLogRuleModel = (eventName, rule) =>
+{
+  var metadata = {
+    DeviceGroup: rule.groupId,
+    Calculation : rule.calculation,
+    TimePeriod: rule.timePeriod,
+    SeverityLevel: rule.severity,
+    ConditionCount: rule.conditions.length,
+    FirstFieldChosen: rule.conditions[0].field,
+    FirstOperatorChosen: rule.conditions[0].operator
+  };
 
-export const toRuleDiagnosticsModel = (eventName, rule) => toDiagnosticsModel(eventName, toLogRuleModel(rule));
+  return toDiagnosticsModel(eventName, metadata);
+}
+
+export const toRuleStatusModel = (eventName, ruleStatusValue) => {
+  var metadata = {
+    RuleStatus: ruleStatusValue
+  };
+
+  return toDiagnosticsModel(eventName, metadata);
+}
+
+export const toSeverityModel = (eventName, severityLevelValue) => {
+  var metadata = {
+    SeverityLevel: severityLevelValue
+  };
+
+  return toDiagnosticsModel(eventName, metadata);
+};
+
+export const toOperatorChosenModel = (
+    eventName,
+    operatorChosenValue,
+    conditionNumberValue) => {
+  var metadata = {
+    OperatorChosen: operatorChosenValue,
+    ConditionNumber: conditionNumberValue,
+  };
+
+  return toDiagnosticsModel(eventName, metadata);
+};
+
+export const toFieldChosenModel = (
+    eventName,
+    fieldChosenValue,
+    conditionNumberValue) => {
+  var metadata = {
+    FieldChosen: fieldChosenValue,
+    ConditionNumber: conditionNumberValue
+  };
+
+  return toDiagnosticsModel(eventName, metadata);
+};
+
+export const toCalculationModel = (eventName, calculationType) => {
+  var metadata = {
+    Calculation: calculationType
+  };
+
+  return toDiagnosticsModel(eventName, metadata);
+};
+
+export const toDeviceGroupModel = (eventName, deviceGroupName) => {
+  var metadata = {
+    DeviceGroup: deviceGroupName
+  };
+
+  return toDiagnosticsModel(eventName, metadata);
+};

--- a/src/services/models/logEventModels.js
+++ b/src/services/models/logEventModels.js
@@ -65,7 +65,7 @@ export const toCalculationModel = (eventName, calculationType) => {
   return toDiagnosticsModel(eventName, metadata);
 };
 
-export const toDeviceGroupModel = (eventName, deviceGroupName) => {
+export const toDeviceGroupLogModel = (eventName, deviceGroupName) => {
   var metadata = {
     DeviceGroup: deviceGroupName
   };

--- a/src/services/models/logEventModels.js
+++ b/src/services/models/logEventModels.js
@@ -17,58 +17,8 @@ export const toLogRuleModel = (eventName, rule) =>
   return toDiagnosticsModel(eventName, metadata);
 }
 
-export const toRuleStatusModel = (eventName, ruleStatusValue) => {
-  var metadata = {
-    RuleStatus: ruleStatusValue
-  };
-
+export const toSinglePropertyLogModel = (eventName, propertyTitle, property) => {
+  var metadata = {};
+  metadata[propertyTitle] = property;
   return toDiagnosticsModel(eventName, metadata);
 }
-
-export const toSeverityModel = (eventName, severityLevelValue) => {
-  var metadata = {
-    SeverityLevel: severityLevelValue
-  };
-
-  return toDiagnosticsModel(eventName, metadata);
-};
-
-export const toOperatorChosenModel = (
-    eventName,
-    operatorChosenValue,
-    conditionNumberValue) => {
-  var metadata = {
-    OperatorChosen: operatorChosenValue,
-    ConditionNumber: conditionNumberValue,
-  };
-
-  return toDiagnosticsModel(eventName, metadata);
-};
-
-export const toFieldChosenModel = (
-    eventName,
-    fieldChosenValue,
-    conditionNumberValue) => {
-  var metadata = {
-    FieldChosen: fieldChosenValue,
-    ConditionNumber: conditionNumberValue
-  };
-
-  return toDiagnosticsModel(eventName, metadata);
-};
-
-export const toCalculationModel = (eventName, calculationType) => {
-  var metadata = {
-    Calculation: calculationType
-  };
-
-  return toDiagnosticsModel(eventName, metadata);
-};
-
-export const toDeviceGroupLogModel = (eventName, deviceGroupName) => {
-  var metadata = {
-    DeviceGroup: deviceGroupName
-  };
-
-  return toDiagnosticsModel(eventName, metadata);
-};

--- a/src/services/models/logEventModels.js
+++ b/src/services/models/logEventModels.js
@@ -2,7 +2,7 @@
 
 import { toDiagnosticsModel } from 'services/models';
 
-export const toLogRuleModel = (eventName, rule) =>
+export const toRuleDiagnosticsModel = (eventName, rule) =>
 {
   var metadata = {
     DeviceGroup: rule.groupId,
@@ -17,7 +17,7 @@ export const toLogRuleModel = (eventName, rule) =>
   return toDiagnosticsModel(eventName, metadata);
 }
 
-export const toSinglePropertyLogModel = (eventName, propertyTitle, property) => {
+export const toSinglePropertyDiagnosticsModel = (eventName, propertyTitle, property) => {
   var metadata = {};
   metadata[propertyTitle] = property;
   return toDiagnosticsModel(eventName, metadata);

--- a/src/store/reducers/appReducer.js
+++ b/src/store/reducers/appReducer.js
@@ -44,9 +44,8 @@ export const epics = createEpicScenario({
     epic: ({ payload }, store) => {
       const diagnosticsOptIn = getDiagnosticsOptIn(store.getState());
       if (diagnosticsOptIn) {
-        payload.userProperties = {};
         payload.sessionId = getSessionId(store.getState());
-        payload.userProperties.CurrentWindow = getCurrentWindow(store.getState());
+        payload.eventProperties.CurrentWindow = getCurrentWindow(store.getState());
         return DiagnosticsService.logEvent(payload)
         /* We don't want anymore action to be executed after this call
             and hence return empty observable */

--- a/src/store/reducers/appReducer.js
+++ b/src/store/reducers/appReducer.js
@@ -144,15 +144,6 @@ export const epics = createEpicScenario({
       GitHubService.getReleaseInfo()
         .map(toActionCreator(redux.actions.getReleaseInformation, fromAction))
         .catch(handleError(fromAction))
-  },
-
-  updateCurrentWindow: {
-    type: 'APP_SET_CURRENT_WINDOW',
-    epic: fromAction => {
-      const action = [];
-      action.push(toActionCreator(redux.actions.updateCurrentWindow, fromAction)(fromAction.payload));
-      return action;
-    }
   }
 
 });

--- a/src/store/reducers/appReducer.js
+++ b/src/store/reducers/appReducer.js
@@ -44,8 +44,9 @@ export const epics = createEpicScenario({
     epic: ({ payload }, store) => {
       const diagnosticsOptIn = getDiagnosticsOptIn(store.getState());
       if (diagnosticsOptIn) {
-        payload.eventProperties.SessionId = getSessionId(store.getState());
-        payload.eventProperties.CurrentWindow = getCurrentWindow(store.getState());
+        payload.userProperties = {};
+        payload.userProperties.SessionId = getSessionId(store.getState());
+        payload.userProperties.CurrentWindow = getCurrentWindow(store.getState());
         return DiagnosticsService.logEvent(payload)
         /* We don't want anymore action to be executed after this call
             and hence return empty observable */

--- a/src/store/reducers/appReducer.js
+++ b/src/store/reducers/appReducer.js
@@ -3,6 +3,7 @@
 import 'rxjs';
 import { Observable } from 'rxjs';
 import { AuthService, ConfigService, GitHubService, DiagnosticsService } from 'services';
+import moment from 'moment';
 import { schema, normalize } from 'normalizr';
 import { createSelector } from 'reselect';
 import update from 'immutability-helper';
@@ -23,7 +24,6 @@ import { svgs, compareByProperty } from 'utilities';
 // ========================= Epics - START
 const handleError = fromAction => error =>
   Observable.of(redux.actions.registerError(fromAction.type, { error, fromAction }));
-const uuidv1 = require('uuid/v1');
 
 export const epics = createEpicScenario({
   /** Initializes the redux state */
@@ -45,7 +45,7 @@ export const epics = createEpicScenario({
       const diagnosticsOptIn = getDiagnosticsOptIn(store.getState());
       if (diagnosticsOptIn) {
         payload.userProperties = {};
-        payload.userProperties.SessionId = getSessionId(store.getState());
+        payload.sessionId = getSessionId(store.getState());
         payload.userProperties.CurrentWindow = getCurrentWindow(store.getState());
         return DiagnosticsService.logEvent(payload)
         /* We don't want anymore action to be executed after this call
@@ -185,7 +185,7 @@ const initialState = {
     diagnosticsOptIn: true
   },
   userPermissions: new Set(),
-  sessionId: uuidv1(),
+  sessionId: moment().utc().unix(),
   currentWindow: ''
 };
 


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
Add diagnostics logging for rule create/update events. Added the following metrics:
Rule_NewClick
Rule_EditClick
Rule_DeviceGroupClick
Rule_CalculationClick
Rule_FieldClick
Rule_OperatorClick
Rule_AddConditionClick
Rule_SeverityLevelClick
Rule_StatusToggle
Rule_ApplyClick
Rule_CancelClick
Rule_TopXCloseClick

Also includes new "sessionid" sections of diagnostics call, which logs the time in ms since Jan 1, 1970 when the page was loaded (amplitude expects session id in this format). This fields will be added by diagnostics to enable logging of session id to amplitude--until those changes go in it will be ignored by the backend. 

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-remote-monitoring-webui/1064)
<!-- Reviewable:end -->
