### PR TITLE
Rule updates need to send ETag

### DIFF
--- a/src/components/pages/rules/flyouts/ruleDelete/deleteRule.js
+++ b/src/components/pages/rules/flyouts/ruleDelete/deleteRule.js
@@ -14,7 +14,7 @@ import {
 } from 'components/shared';
 import { svgs } from 'utilities';
 import { TelemetryService } from 'services';
-import { toNewRuleRequestModel } from 'services/models';
+import { toEditRuleRequestModel } from 'services/models';
 import Flyout from 'components/shared/flyout';
 import { RuleSummary } from '..';
 
@@ -85,7 +85,7 @@ export class DeleteRule extends Component {
     this.setState({ isPending: true, error: null });
     rule.enabled = status;
     this.subscription =
-      TelemetryService.updateRule(rule.id, toNewRuleRequestModel(rule))
+      TelemetryService.updateRule(rule.id, toEditRuleRequestModel(rule))
         .subscribe(
           (updatedRule) => {
             this.props.refresh();

--- a/src/components/pages/rules/flyouts/ruleEditor/ruleEditor.js
+++ b/src/components/pages/rules/flyouts/ruleEditor/ruleEditor.js
@@ -28,7 +28,7 @@ import {
 import Flyout from 'components/shared/flyout';
 import { IoTHubManagerService, TelemetryService } from 'services';
 import {
-  toNewRuleRequestModel,
+  toEditRuleRequestModel,
   ruleCalculations,
   ruleTimePeriods,
   ruleOperators,
@@ -149,7 +149,7 @@ export class RuleEditor extends LinkedComponent {
       };
       logEvent(toRuleDiagnosticsModel('Rule_ApplyClick', requestProps));
       if (this.props.rule) { // If rule object exist then update the existing rule
-        this.subscription = TelemetryService.updateRule(this.props.rule.id, toNewRuleRequestModel(requestProps))
+        this.subscription = TelemetryService.updateRule(this.props.rule.id, toEditRuleRequestModel(requestProps))
           .subscribe(
             (updatedRule) => {
               modifyRules([{ ...updatedRule, ...countProps }]);
@@ -158,7 +158,7 @@ export class RuleEditor extends LinkedComponent {
             error => this.setState({ error, isPending: false, changesApplied: true })
           );
       } else { // If rule object doesn't exist then create a new rule
-        this.subscription = TelemetryService.createRule(toNewRuleRequestModel(requestProps))
+        this.subscription = TelemetryService.createRule(toEditRuleRequestModel(requestProps))
           .subscribe(
             (createdRule) => {
               insertRules([{ ...createdRule, ...countProps }]);

--- a/src/components/pages/rules/flyouts/ruleStatus/ruleStatus.js
+++ b/src/components/pages/rules/flyouts/ruleStatus/ruleStatus.js
@@ -12,7 +12,7 @@ import {
 } from 'components/shared';
 import { svgs } from 'utilities';
 import { TelemetryService } from 'services';
-import { permissions, toNewRuleRequestModel } from 'services/models';
+import { permissions, toEditRuleRequestModel } from 'services/models';
 import Flyout from 'components/shared/flyout';
 
 import './ruleStatus.css';
@@ -60,7 +60,7 @@ export class RuleStatus extends Component {
     }));
     this.subscription = Observable.from(requestPropList)
       .flatMap((rule) =>
-        TelemetryService.updateRule(rule.id, toNewRuleRequestModel(rule))
+        TelemetryService.updateRule(rule.id, toEditRuleRequestModel(rule))
           .map(() => rule)
       )
       .subscribe(

--- a/src/services/models/telemetryModels.js
+++ b/src/services/models/telemetryModels.js
@@ -123,7 +123,7 @@ export const toMessagesModel = (response = {}) => getItems(response)
     'time': 'time'
   }));
 
-export const toNewRuleRequestModel = ({
+export const toEditRuleRequestModel = ({
   name,
   description,
   groupId,
@@ -131,7 +131,8 @@ export const toNewRuleRequestModel = ({
   severity,
   enabled,
   calculation,
-  timePeriod
+  timePeriod,
+  eTag
 }) => {
   const Conditions = conditions.map(condition => ({
     Field: condition.field,
@@ -146,6 +147,7 @@ export const toNewRuleRequestModel = ({
     Enabled: enabled,
     Calculation: calculation,
     TimePeriod: timePeriod,
+    ETag: eTag,
     Conditions
   };
 }


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

UI needs to send the ETag when updating rules.  Java backend requires this.  The dotNet backend should require it, but does not (@zhang-hua to create an issue in the dotNet repo to correct it).

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
