### PR TITLE
Use POST Request for long queries

### DIFF
--- a/src/components/pages/maintenance/maintenance.js
+++ b/src/components/pages/maintenance/maintenance.js
@@ -57,6 +57,7 @@ export class Maintenance extends Component {
     const devices = deviceIds.length ? deviceIds.join(',') : undefined;
     const [timeParams] = getIntervalParams(timeInterval || this.props.timeInterval);
     const params = { ...timeParams, devices };
+    const jobParams = { ...timeParams };
     this.setState({
       alertsIsPending: true,
       jobsIsPending: true,
@@ -120,7 +121,7 @@ export class Maintenance extends Component {
     );
 
     this.subscriptions.push(
-      IoTHubManagerService.getJobs(params)
+      IoTHubManagerService.getJobs(jobParams)
         .subscribe(
           jobs => {
             const { failedJobsCount, succeededJobsCount } = jobs.reduce(

--- a/src/services/telemetryService.js
+++ b/src/services/telemetryService.js
@@ -45,17 +45,29 @@ export class TelemetryService {
 
   /** Returns a list of alarms (all statuses) */
   static getAlerts(params = {}) {
-    return this.getOrPost(`${ENDPOINT}alarms`, params, toAlertsModel);
+    if (params.devices && !Array.isArray(params.devices)) {
+      params.devices = params.devices.split(",");
+    }
+    return HttpClient.post(`${ENDPOINT}alarms`, params)
+        .map(toAlertsModel);
   }
 
   /** Returns a list of active alarms (open or ack) */
   static getActiveAlerts(params = {}) {
-    return this.getOrPost(`${ENDPOINT}alarmsbyrule`, params, toActiveAlertsModel);
+    if (params.devices && !Array.isArray(params.devices)) {
+      params.devices = params.devices.split(",");
+    }
+    return HttpClient.post(`${ENDPOINT}alarmsbyrule`, params)
+        .map(toActiveAlertsModel);
   }
 
   /** Returns a list of alarms created from a given rule */
   static getAlertsForRule(id, params = {}) {
-    return this.getOrPost(`${ENDPOINT}alarmsbyrule/${id}`, params, toAlertsForRuleModel);
+    if (params.devices && !Array.isArray(params.devices)) {
+      params.devices = params.devices.split(",");
+    }
+    return HttpClient.post(`${ENDPOINT}alarmsbyrule/${id}`, params)
+        .map(toAlertsForRuleModel);
   }
 
   /** Returns a list of alarms created from a given rule */
@@ -71,12 +83,8 @@ export class TelemetryService {
 
   /** Returns a telemetry events */
   static getTelemetryByMessages(params = {}) {
-    const devicesArr = params.devices || [];
-    const _params = {
-      ...params,
-      devices: (devicesArr).map(encodeURIComponent).join()
-    };
-    return this.getOrPost(`${ENDPOINT}messages`, _params, toMessagesModel, devicesArr);
+    return HttpClient.post(`${ENDPOINT}messages`, params)
+        .map(toMessagesModel);
   }
 
   static getTelemetryByDeviceIdP1M(devices = []) {
@@ -101,21 +109,4 @@ export class TelemetryService {
     return HttpClient.delete(`${ENDPOINT}rules/${id}`)
       .map(() => ({ deletedRuleId: id }));
   }
-
-  static getOrPost(url, params, toModel, devicesArr = undefined) {
-    const urlWithParams = `${url}?${stringify(params)}`;
-    if (urlWithParams.length > 2048) {
-      if (devicesArr) {
-        params.devices = devicesArr;
-      } else if (params.devices && !Array.isArray(params.devices)) {
-        params.devices = params.devices.split(",");
-      }
-      return HttpClient.post(url, params)
-        .map(toModel);
-    } else {
-      return HttpClient.get(urlWithParams)
-        .map(toModel)
-    }
-  }
-
 }


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
Telemetry get request urls can be longer than 2048 characters if have many devices. Send a POST request instead for these types of queries. Also remove devices from iot hub manager jobs query, as jobs cannot be filtered on devices and this query failed if the url got too long.
Related to this issue: https://github.com/Azure/azure-iot-pcs-remote-monitoring-dotnet/issues/108

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-remote-monitoring-webui/1178)
<!-- Reviewable:end -->
