### PR TITLE
Fix clicking on map popup to open device details

### DIFF
--- a/src/components/pages/dashboard/panels/map/mapPanel.js
+++ b/src/components/pages/dashboard/panels/map/mapPanel.js
@@ -91,7 +91,7 @@ export class MapPanel extends Component {
     popupContentBox.appendChild(name);
 
     popupContentBox.onclick = () => {
-      // Check this to void any potential attempts to refernce the component after unmount
+      // Check this to void any potential attempts to reference the component after unmount
       if (this) this.openDeviceDetails(properties.id);
     };
 
@@ -187,7 +187,7 @@ export class MapPanel extends Component {
   closeDeviceDetails = () => this.setState({ selectedDeviceId: undefined });
 
   render() {
-    const { t, isPending, devices, mapKeyIsPending, azureMapsKey, error } = this.props;
+    const { t, isPending, mapKeyIsPending, azureMapsKey, error } = this.props;
     const showOverlay = !error && isPending && mapKeyIsPending;
     return (
       <Panel className="map-panel-container">
@@ -205,7 +205,7 @@ export class MapPanel extends Component {
         { error && <PanelError><AjaxError t={t} error={error} /></PanelError> }
         {
           this.state.selectedDeviceId
-          && <DeviceDetailsContainer onClose={this.closeDeviceDetails} device={devices[this.state.selectedDeviceId]} />
+          && <DeviceDetailsContainer onClose={this.closeDeviceDetails} deviceId={this.state.selectedDeviceId} />
         }
       </Panel>
     );


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

Click on map pin popup should open the device details. A change was made a couple of weeks ago to pass the device ID to the flyout instead of the full device object.  This use case was missed in making that change.


**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-remote-monitoring-webui/1198)
<!-- Reviewable:end -->
