### PR TITLE
Bug fix for Alerts on device details page

### DIFF
--- a/src/services/models/telemetryModels.js
+++ b/src/services/models/telemetryModels.js
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-import { camelCaseReshape, getItems } from 'utilities';
+import { camelCaseReshape, getItems, reshape } from 'utilities';
 import update from 'immutability-helper';
 
 export const ruleCalculations = ['Average', 'Instant'];
@@ -159,3 +159,11 @@ export const toEditRuleRequestModel = ({
     Actions
   };
 }
+
+export const toTelemetryRequestModel = (alarmQueryModel = {}) => reshape(alarmQueryModel, {
+  'from': 'From',
+  'to': 'To',
+  'order': 'Order',
+  'limit': 'Limit',
+  'devices': 'Devices'
+});

--- a/src/services/telemetryService.js
+++ b/src/services/telemetryService.js
@@ -11,7 +11,8 @@ import {
   toMessagesModel,
   toRuleModel,
   toRulesModel,
-  toStatusModel
+  toStatusModel,
+  toTelemetryRequestModel
 } from './models';
 
 const ENDPOINT = Config.serviceUrls.telemetry;
@@ -48,7 +49,7 @@ export class TelemetryService {
     if (params.devices && !Array.isArray(params.devices)) {
       params.devices = params.devices.split(",");
     }
-    return HttpClient.post(`${ENDPOINT}alarms`, params)
+    return HttpClient.post(`${ENDPOINT}alarms`, toTelemetryRequestModel(params))
         .map(toAlertsModel);
   }
 
@@ -57,7 +58,7 @@ export class TelemetryService {
     if (params.devices && !Array.isArray(params.devices)) {
       params.devices = params.devices.split(",");
     }
-    return HttpClient.post(`${ENDPOINT}alarmsbyrule`, params)
+    return HttpClient.post(`${ENDPOINT}alarmsbyrule`, toTelemetryRequestModel(params))
         .map(toActiveAlertsModel);
   }
 
@@ -66,7 +67,7 @@ export class TelemetryService {
     if (params.devices && !Array.isArray(params.devices)) {
       params.devices = params.devices.split(",");
     }
-    return HttpClient.post(`${ENDPOINT}alarmsbyrule/${id}`, params)
+    return HttpClient.post(`${ENDPOINT}alarmsbyrule/${id}`, toTelemetryRequestModel(params))
         .map(toAlertsForRuleModel);
   }
 
@@ -83,7 +84,7 @@ export class TelemetryService {
 
   /** Returns a telemetry events */
   static getTelemetryByMessages(params = {}) {
-    return HttpClient.post(`${ENDPOINT}messages`, params)
+    return HttpClient.post(`${ENDPOINT}messages`, toTelemetryRequestModel(params))
         .map(toMessagesModel);
   }
 


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation 
The alerts section on the device details page flyouts was showing ALL alerts for all the device(s) rather than showing alerts for the particular device only. The issue was traced to the POST calls to Telemetry service. The call body contained JSON attributes in lower case, but JAVA JsonProperty mapping expected Pascal case attributes. To make the calls consistent with mappings (QueryApiModel) the attributes, 
1. Devices
2. From
3. To
4. Limit
5. Order

are converted into Pascal case. This does not break the dotnet version.

**Checklist:**

- [x] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-remote-monitoring-webui/1202)
<!-- Reviewable:end -->
