### PR TITLE
Read message schema from module twins

### DIFF
--- a/src/components/pages/rules/flyouts/ruleEditor/ruleEditor.js
+++ b/src/components/pages/rules/flyouts/ruleEditor/ruleEditor.js
@@ -259,11 +259,20 @@ export class RuleEditor extends LinkedComponent {
       if (group.id === groupId) {
         if (this.subscription) this.subscription.unsubscribe();
         this.subscription = IoTHubManagerService.getDevices(group.conditions)
+          .flatMap(devices => {
+            const deviceIds = devices.map(dvc => `'${dvc.id}'`).join(",");
+            const modulesQuery = `deviceId IN [${deviceIds}]`;
+            return IoTHubManagerService.getModules(modulesQuery);
+          }, (devices, modules) => {
+            return [devices, modules];
+          })
           .subscribe(
-            groupDevices => {
+            groupDevicesAndModules => {
+              var groupDevices = groupDevicesAndModules[0];
+              var modules = groupDevicesAndModules[1];
               this.setState({
                 fieldQueryPending: false,
-                fieldOptions: this.getConditionFields(groupDevices),
+                fieldOptions: this.getConditionFields(groupDevices, modules),
                 devicesAffected: groupDevices.length,
                 isPending: false
               });
@@ -276,7 +285,7 @@ export class RuleEditor extends LinkedComponent {
     });
   }
 
-  getConditionFields(devices) {
+  getConditionFields(devices, modules) {
     const conditions = new Set(); // Using a set to avoid searching the array multiple times in the every
     devices.forEach(({ telemetry = {} }) => {
       Object.values(telemetry).forEach(({ messageSchema: { fields } }) => {
@@ -285,6 +294,28 @@ export class RuleEditor extends LinkedComponent {
         })
       })
     })
+
+    /* Expected example schema for modules
+    "reported": {
+      "Telemetry": {
+        "MessageSchema": {
+          "Fields": {
+            "temperature": "Double",
+          }
+        }
+      }
+    }
+    */
+    modules.forEach(({ reported = {} }) => {
+      if ('telemetry' in reported) {
+        Object.values(reported.telemetry).forEach(({ fields }) => {
+          Object.keys(fields).forEach((field) => {
+            if (field.toLowerCase().indexOf('unit') === -1) conditions.add(field);
+          })
+        })
+      }
+    })
+
     return [...conditions.values()].map(field => ({ label: field, value: field }));
   }
 

--- a/src/services/iotHubManagerService.js
+++ b/src/services/iotHubManagerService.js
@@ -8,6 +8,7 @@ import { HttpClient } from 'utilities/httpClient';
 import {
   toDevicesModel,
   toDeviceModel,
+  toModulesModel,
   toJobsModel,
   toJobStatusModel,
   toDevicePropertiesModel,
@@ -27,6 +28,12 @@ export class IoTHubManagerService {
     const query = encodeURIComponent(JSON.stringify(conditions));
     return HttpClient.get(`${ENDPOINT}devices?query=${query}`)
       .map(toDevicesModel);
+  }
+
+  /** Returns a list of all modules */
+  static getModules(query) {
+    return HttpClient.post(`${ENDPOINT}modules/query`, `"${query}"`)
+      .map(toModulesModel);
   }
 
   /** Returns a list of all jobs */

--- a/src/services/models/iotHubManagerModels.js
+++ b/src/services/models/iotHubManagerModels.js
@@ -51,6 +51,16 @@ export const toDeviceModel = (device = {}) => {
   });
 }
 
+export const toModulesModel = (response = {}) => getItems(response)
+  .map(toModuleModel);
+
+export const toModuleModel = (module = {}) => camelCaseReshape(module, {
+  'desired': 'desired',
+  'reported': 'reported',
+  'deviceId': 'deviceId',
+  'moduleId': 'moduleId'
+});
+
 export const toJobsModel = (response = []) => response.map(job => camelCaseReshape(job, {
   'jobId': 'jobId',
   'createdTimeUtc': 'createdTimeUtc',


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
When edge devices are reporting telemetry there is currently no way to create rules against that data. This is because the rules flyout only looks in the device twin for message schema. 

This PR makes a query for modules in the same device group to see if they are reporting a message schema in the module twin. The expected schema to use is something like:

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
